### PR TITLE
Fix 0 capacity slice initialization in ScanAll() receiver function.

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -127,7 +127,7 @@ func (s *Scanner) Peek(v string) bool {
 // ScanAll scans all Tokens representing UTF-8 encoded Unicode characters from
 // the byte buffer underlying the Scanner.
 func (s *Scanner) ScanAll() ([]Token, bool) {
-	result := make([]Token, s.Cursor.End)
+	result := make([]Token, 0, len(s.Buffer))
 	for s.Scan() {
 		t := s.Token()
 		result = append(result, t)


### PR DESCRIPTION
The previous code was not buggy, but redundant
and ineffective. The size of the array underlying
the result slice was set to 0 because this is
the start of the scanner cursor right after it's
initialized. Now the capacity matches the number
of bytes in the buffer, which should be optimal
for most cases given that multi-byte unicode
runes are less likely to occur.
