### PR TITLE
Fix CI codecov upload

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.19', '1.21' ]
+        go-version: [ '1.21' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,7 +34,8 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Coverage
-      uses: codecov/codecov-action@v3.1.4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true


### PR DESCRIPTION
- Removed Go 1.19 from the CI matrix
- Fixed codecov github action
